### PR TITLE
advWaterfall: list/label clipping fixes (#28, #29)

### DIFF
--- a/src/customviz/com-company-advWaterfall/advWaterfall.js
+++ b/src/customviz/com-company-advWaterfall/advWaterfall.js
@@ -195,6 +195,20 @@ define([
     return w;
   }
 
+  // Right-truncate text to fit within budget pixels; appends ellipsis when truncated.
+  function truncateText(text, budget, fontFamily, fontSize) {
+    var s = String(text);
+    if (measureTextWidth(s, fontFamily, fontSize) <= budget) return s;
+    var ellipsis = '…';
+    var lo = 0, hi = s.length;
+    while (lo < hi) {
+      var mid = Math.ceil((lo + hi) / 2);
+      if (measureTextWidth(s.slice(0, mid) + ellipsis, fontFamily, fontSize) <= budget) lo = mid;
+      else hi = mid - 1;
+    }
+    return (lo > 0 ? s.slice(0, lo) : '') + ellipsis;
+  }
+
   AdvWaterfall.VERSION = '1.0.0';
 
   function AdvWaterfall(sID, sDisplayName, sOrigin, sVersion) {
@@ -413,7 +427,10 @@ define([
               .attr('pointer-events', 'none');
           }
           var lw = measureTextWidth(labelText, Y_FONT, 11);
-          if (lw + 8 < segW) {
+          // #29: show truncated in-segment label when the full string doesn't fit
+          var inSegLabel = lw + 8 < segW ? labelText
+            : (segW >= 20 ? truncateText(labelText, segW - 8, Y_FONT, 11) : null);
+          if (inSegLabel !== null) {
             rowG.append('text')
               .attr({
                 x: x0 + 6,
@@ -424,7 +441,7 @@ define([
                 'font-size': 11
               })
               .attr('fill', pickContrastFill(fill))
-              .text(labelText)
+              .text(inSegLabel)
               .append('title').text(labelText);
           }
           cursor += direction * segW;
@@ -482,6 +499,10 @@ define([
           });
           var blockW = maxValueW + 8 + maxNameW;
           var blockLeft = direction > 0 ? labelX : labelX - blockW;
+          // #28: keep list from crossing the zero line into the gutter
+          if (direction < 0 && settings.showZeroLine && minVal <= 0 && maxVal >= 0) {
+            blockLeft = Math.max(blockLeft, x(0) + 5);
+          }
           var valueColRight = blockLeft + maxValueW;
           var nameColLeft = blockLeft + maxValueW + 8;
 
@@ -526,6 +547,8 @@ define([
         }
 
         // Left gutter: category name (top) + signed subtotal (bottom)
+        // #29: right-truncate labels that exceed the available gutter width
+        var gutterBudget = margin.left - 14;
         var gutter = svg.append('g').attr('transform',
           'translate(' + margin.left + ',' + (margin.top + ci * bandHeight + bandHeight / 2) + ')');
         gutter.append('text')
@@ -537,7 +560,7 @@ define([
           .attr('font-family', Y_FONT)
           .attr('font-size', Y_FONT_SIZE)
           .attr('fill', 'currentColor')
-          .text(disp(cat.name) || '')
+          .text(truncateText(disp(cat.name) || '', gutterBudget, Y_FONT, Y_FONT_SIZE))
           .append('title').text(fullListText);
         var subtotalText = cat._isClosing
           ? formatNumber(cat.endCum, settings)
@@ -555,7 +578,7 @@ define([
           .attr('font-size', Y_SUB_SIZE)
           .attr('fill', 'currentColor')
           .attr('opacity', cat._isClosing ? 0.85 : 0.7)
-          .text(subtotalText)
+          .text(truncateText(subtotalText, gutterBudget, Y_FONT, Y_SUB_SIZE))
           .append('title').text(subtotalTip);
       });
 

--- a/src/customviz/com-company-advWaterfall/plugin.xml
+++ b/src/customviz/com-company-advWaterfall/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<obiplugin xmlns="http://plugin.frameworks.tech.bi.oracle" id="com-company-advWaterfall" name="com-company-advWaterfall" version="1.0.0.1745945000000" optimized="false" optimizable="true" category="customviz" categoryVersion="1.0.0.1547829178628">
+<obiplugin xmlns="http://plugin.frameworks.tech.bi.oracle" id="com-company-advWaterfall" name="com-company-advWaterfall" version="1.0.0.1777600000000" optimized="false" optimizable="true" category="customviz" categoryVersion="1.0.0.1547829178628">
     <resources>
         <resource-folder id="nls" path="nls" optimizable="true">
             <extensions>


### PR DESCRIPTION
## Summary

- **#28 – list overlaps zero line for negative bars near zero**: clamp `blockLeft` to `x(0) + 5` for negative-direction bars when `showZeroLine` is on and zero is in domain. Positive-direction bars are untouched. Affected scenario: Investing-style charts where a category starts close to zero (e.g., "Bothra Metals: -2K") and the step list was rendering on top of the zero reference line and gutter labels.

- **#29 – long category labels left-clip**: add a `truncateText` binary-search helper that right-truncates text to a pixel budget and appends `…`. Applied to (a) gutter category name and subtotal rows — budget is `margin.left - 14`, so the start of the label is always visible; (b) in-segment step labels — previously suppressed entirely when too wide, now shown truncated if the segment is at least 20 px wide. Affected scenario: categories like "Aluminium and Aluminium Products" that previously rendered as "lminium and Aluminium Products" due to left-edge SVG clipping.

- **plugin.xml** version bumped to `1.0.0.1777600000000`.

## Test plan

- [ ] Investing-style dataset with a small negative category starting near 0: verify step list in *List* or *Cumulative + List* mode renders to the right of the zero line, not behind it
- [ ] Same chart with `showZeroLine = false`: list placement unchanged
- [ ] Category named "Aluminium and Aluminium Products" in a narrow widget: label shows "Aluminium and Alumi…" (or similar), never clips on the left
- [ ] Subtotal row (signed delta) for the same category also truncates correctly
- [ ] In-segment step label on a narrow bar segment: shows truncated text instead of nothing
- [ ] Normal charts (all-positive, wide panel, short labels): no visual change

closes #28 closes #29

https://claude.ai/code/session_017hh3TQUabYbCAq1a79WRv9

---
_Generated by [Claude Code](https://claude.ai/code/session_017hh3TQUabYbCAq1a79WRv9)_